### PR TITLE
Fix JitPack build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sdk install java 17.0.10-tem
+  - sdk use java 17.0.10-tem


### PR DESCRIPTION
Was trying to use this project (which seems super useful to provide mod compatibility especially for old unmaintained mods!) but couldn't import it, thought I didn't have the right repo setup, but nah.

Turns out the [0.1.2-beta.1/2 builds fail](https://jitpack.io/com/github/Bawnorton/MixinSquared/0.1.2-beta.2/build.log) because JitPack uses Java 8 by default and the neoforge task can't find a Java 17 toolchain.

Easy fix is to provide JitPack with Java 17 from the beginning, which can be done via using SDKMAN! inside `jitpack.yml`.
([Build tested to work!](https://jitpack.io/com/github/Fourmisain/MixinSquared/47eaa9f7ef/build.log))